### PR TITLE
feat: add LeaveCredits entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/synacy/leavesmanagement/leavecredits/LeaveCredits.java
+++ b/src/main/java/com/synacy/leavesmanagement/leavecredits/LeaveCredits.java
@@ -1,31 +1,29 @@
 package com.synacy.leavesmanagement.leavecredits;
 
-import com.synacy.leavesmanagement.user.User;
 import jakarta.persistence.*;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import com.synacy.leavesmanagement.user.User;
 
 @Entity
 @Setter
 @Getter
 @NoArgsConstructor
-@EqualsAndHashCode(of = "id")
 public class LeaveCredits {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "leave_credits_sequence")
     @SequenceGenerator(name = "leave_credits_sequence", sequenceName = "leave_credits_sequence", allocationSize = 1)
-    private Long id;
+    private Long creditId;
 
     @OneToOne
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
     @Column(nullable = false)
-    private int totalCredits = 30;
+    private int totalCredits;
 
     @Column(nullable = false)
-    private int remainingCredits = 30;
+    private int remainingCredits;
 }


### PR DESCRIPTION
Added the LeaveCredits entity with:
- sequence generator for ID
- one-to-one relationship with User
- fields for totalCredits and remainingCredits (default 30)